### PR TITLE
Fix automated build

### DIFF
--- a/.github/workflows/pr-close-signal.yaml
+++ b/.github/workflows/pr-close-signal.yaml
@@ -16,7 +16,7 @@ jobs:
           mkdir -p ./pr
           printf ${{ github.event.number }} > ./pr/NUM
       - name: Upload Diff
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pr 
           path: ./pr

--- a/.github/workflows/pr-receive.yaml
+++ b/.github/workflows/pr-receive.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: "Upload PR number"
         id: upload
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: ${{ github.workspace }}/NR
@@ -107,20 +107,20 @@ jobs:
         shell: Rscript {0}
 
       - name: "Upload PR"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: ${{ env.PR }}
 
       - name: "Upload Diff"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: diff
           path: ${{ env.CHIVE }}
           retention-days: 1
       
       - name: "Upload Build"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: built
           path: ${{ env.MD }}

--- a/.github/workflows/sandpaper-main.yaml
+++ b/.github/workflows/sandpaper-main.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - master
-  schedule:
-    - cron: '0 0 * * 2'
   workflow_dispatch:
     inputs:
       name:
@@ -21,7 +19,7 @@ on:
 jobs:
   full-build:
     name: "Build Full Site"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
       contents: write


### PR DESCRIPTION
Pins to a version of ubuntu that is compatible with the sandpaper package used to render the lesson. Removes cron setting from GitHub actions since the lesson is no longer rapidly changing. https://github.com/carpentries/sandpaper/issues/605

Fixes #13